### PR TITLE
Add mappings for community messages

### DIFF
--- a/src/entities/DBMessage-util.ts
+++ b/src/entities/DBMessage-util.ts
@@ -109,6 +109,14 @@ const PRE_DEFINED_MESSAGES: { [k: number]: string | ((m: WAMessage) => string) }
   },
   [WAMessageStubType.BLOCK_CONTACT]: message =>
     (message.messageStubParameters![0] ? 'You blocked this contact' : 'You unblocked this contact'),
+  [WAMessageStubType.COMMUNITY_CREATE]: message => `{{${message.participant}}} created the community "${message.messageStubParameters![1]}"`,
+  [WAMessageStubType.COMMUNITY_LINK_SIBLING_GROUP]: message => `{{${message.participant}}} added the group "${message.messageStubParameters![1]}"`,
+  [WAMessageStubType.COMMUNITY_UNLINK_SIBLING_GROUP]: message => `{{${message.participant}}} removed the group "${message.messageStubParameters![1]}"`,
+  [WAMessageStubType.COMMUNITY_PARTICIPANT_PROMOTE]: message => `{{${message.messageStubParameters![0]}}} is now a community admin`,
+  [WAMessageStubType.COMMUNITY_ALLOW_MEMBER_ADDED_GROUPS]: 'Everyone in this community can now add groups',
+  [WAMessageStubType.COMMUNITY_LINK_PARENT_GROUP]: 'This group was added to the community "{{1}}"',
+  [WAMessageStubType.SUB_GROUP_INVITE_RICH]: 'You joined a group via invite in the community: "{{1}}"',
+  [WAMessageStubType.COMMUNITY_INVITE_RICH]: 'Welcome to the community! Admins will send all important updates here.',
 }
 
 const ATTACHMENT_MAP = {


### PR DESCRIPTION
# Context
* [Linear issue](https://linear.app/texts/issue/PLT-934/whatsapp-fix-message-didnt-render)

# Description
There are a bunch of Whatsapp messages that we're not mapping yet. This PR adds a bunch of them: the ones I've found the original copy for. 

I had to manually look for this kind of messages on my own whatsapp account, and check what was the copy rendered by the official client, which is not very efficient. 

I'm currently looking for a way to find the original copies for every kind of message within the Whatsapp Web source code. In the meantime we can merge this.

## Official client (REFERENCE)
<img src="https://github.com/TextsHQ/platform-whatsapp/assets/855995/e20439a2-2e27-43bf-a17c-4d7cd3432995 " width="300"/>

## Texts BEFORE

<img src="https://github.com/TextsHQ/platform-whatsapp/assets/855995/979c1969-9a2f-4c71-a7e3-732943f631f1" width="500"/>

## Texts AFTER
<img src="https://github.com/TextsHQ/platform-whatsapp/assets/855995/1e0b2dbb-15a3-44c8-a357-783a31fa93e0" width="500"/>
