### PR TITLE
Fix rendering of edited messages containing images

### DIFF
--- a/src/entities/DBMessage.ts
+++ b/src/entities/DBMessage.ts
@@ -171,17 +171,21 @@ export default class DBMessage implements Message {
       delete partial.status
     }
 
-    // If the message is edited and contains an imageMessage, we need to merge the new imageMessage with the old one
-    // as the edited message only contains the new caption
-    if (partial.message?.editedMessage?.message?.imageMessage) {
-      const existingMessage = this.original.message.message
-      // The image could be in the original imageMessage or within the editedMessage
-      // depending on whether it has been edited before
-      const existingImageMessage = existingMessage?.imageMessage || existingMessage?.editedMessage?.message?.imageMessage
+    if (partial.message?.editedMessage?.message) {
+      const existingMessage = extractMessageContent(this.original.message.message)
+      const editedMessage = extractMessageContent(partial.message)
 
-      partial.message.editedMessage.message.imageMessage = {
-        ...(existingImageMessage),
-        ...partial.message.editedMessage.message.imageMessage,
+      // partial.message.editMessage.message can contain:
+      // imageMessage, documentMessage, videoMessage, locationMessage
+      // We need to merge that with the existing message to preserve all the existing properties
+      if (existingMessage?.imageMessage) {
+        partial.message.editedMessage.message.imageMessage = { ...existingMessage.imageMessage, ...editedMessage?.imageMessage }
+      }
+      if (existingMessage?.documentMessage) {
+        partial.message.editedMessage.message.documentMessage = { ...existingMessage.documentMessage, ...editedMessage?.documentMessage }
+      }
+      if (existingMessage?.videoMessage) {
+        partial.message.editedMessage.message.videoMessage = { ...existingMessage.videoMessage, ...editedMessage?.videoMessage }
       }
     }
 


### PR DESCRIPTION
Closes FDBCK-7573.

# Context 
* [Linear issue](https://linear.app/texts/issue/FDBCK-7573/problem-report-from-eugenio-perea-eugenioinvisibleinfocom)

# Description

An image with caption can be edited (to change the caption). When that happens we receive a new payload that contains  an `editedMessage` object with a new `imageMessage` that only contains the new caption. 

This PR makes sure we preserve the existing information of the image by merging it with the new data (the new caption).

# Testing
1. Send an image with a caption from Whatsapp client
2. Edit the caption
3. Check that the image is still rendered in Texts and the new caption is displayed.