### PR TITLE
Create msgRetryCounterCache to store retry counts out of the socket

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "link-preview-js": "2.1.15",
     "match-sorter": "^4.2.1",
     "mem": "^8.0.0",
+    "node-cache": "^5.1.2",
     "pino": "^7.8.0",
     "react": "https://github.com/TextsHQ/react-global-shim#main",
     "sanitize-filename": "^1.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2553,6 +2553,7 @@ __metadata:
     link-preview-js: 2.1.15
     match-sorter: ^4.2.1
     mem: ^8.0.0
+    node-cache: ^5.1.2
     pino: ^7.8.0
     react: "https://github.com/TextsHQ/react-global-shim#main"
     sanitize-filename: ^1.6.3


### PR DESCRIPTION
Contributes to PLT-832.

# Context
* [Linear](https://linear.app/texts/issue/PLT-832/whatsapp-request-ciphertext-messages-from-phoneprimary-device)

# Description
When a message fails to be delivered or decrypted, the user will see a "waiting for this message". When that happens, we should send a "retry message".

This is how the Whatsapp Web client does it:
* [handleMessageRetryRequest](https://github.com/TextsHQ/platform-whatsapp-docs/blob/main/unpacked/app/244670.js#L51) ->  [sendRetry](https://github.com/TextsHQ/platform-whatsapp-docs/blob/main/unpacked/app/723406.js#L14)

This is how whatsmeow does it:
* [decryptMessage](https://github.com/tulir/whatsmeow/blob/main/message.go#L169) -> [sendRetryReceipt](https://github.com/tulir/whatsmeow/blob/main/retry.go#L282) -> [delayedRequestMessageFromPhone](https://github.com/tulir/whatsmeow/blob/main/retry.go#L242) -> [SendMessage](https://github.com/tulir/whatsmeow/blob/main/send.go#L139)

Baileys has a [msgRetryCache](https://github.com/TextsHQ/baileys/blob/master/src/Socket/messages-recv.ts#L72C8-L72C21) object that is used in the [sendRetryRequest](https://github.com/TextsHQ/baileys/blob/master/src/Socket/messages-recv.ts#L129) which is supposed to implement a similar behavior.

However from the user reports this doesn't seem to be working fine.

The best bet I've found to fix this is the fact that in the [official Baileys example](https://github.com/TextsHQ/baileys/blob/master/Example/example.ts#L17-L19), the msgRetryCache is created outside the socket:

```javascript
// external map to store retry counts of messages when decryption/encryption fails
// keep this out of the socket itself, so as to prevent a message decryption/encryption loop across socket restarts
const msgRetryCounterCache = new NodeCache()
```

This PR adds follows the same idea by creating the NodeCache as part of the `WhatsAppAPI` initialization.

Note that I haven't been able to repro the "waiting for message" issue so this is just a tentative fix.