### PR TITLE
Fix mentions when there is an attachment

### DIFF
--- a/src/utils/get-message-compose.ts
+++ b/src/utils/get-message-compose.ts
@@ -60,6 +60,11 @@ const getMessageCompose = async (
       }
 
       media.mimetype = mimeType || 'application/octet-stream'
+
+      if (!('audio' in media) && !('sticker' in media) && !('document' in media)) {
+        media.mentions = msgContent.mentionedUserIDs
+      }
+
       content = media
       if (!!text && !('caption' in media)) {
         sendAdditionalTextMessage = true


### PR DESCRIPTION
Closes PLT-1015

# Context
* [Linear issue](https://linear.app/texts/issue/PLT-1015/whatsapp-mentions-dont-work-with-attachments)

## BEFORE
<img width="500" src="https://github.com/TextsHQ/platform-whatsapp/assets/855995/1b0f6a56-e8c8-42b6-a305-fc8901b0b558"/>

# Description

Fixes mentions when there is an attachment. Note that only some attachments types support mentions, as defined in the [AnyMediaMessageContent type](https://github.com/TextsHQ/baileys/blob/master/src/Types/Message.ts#L108).

## AFTER
<img width="384" alt="image" src="https://github.com/TextsHQ/platform-whatsapp/assets/855995/d299b24a-e98e-4cb2-be07-3a23210f8f6d">

