### PR TITLE
Hide threads when there is only one message and it is a template

### DIFF
--- a/src/entities/DBMessage-util.ts
+++ b/src/entities/DBMessage-util.ts
@@ -36,7 +36,7 @@ const getDisappearingModeMessageText = (exp: number, actor: string) => {
   return `{{${actor}}} uses a default timer for disappearing messages in new chats. All new messages will disappear from this chat ${expDays} days after they're sent.`
 }
 
-const PRE_DEFINED_MESSAGES: { [k: number]: string | ((m: WAMessage) => string) } = {
+export const PRE_DEFINED_MESSAGES: { [k: number]: string | ((m: WAMessage) => string) } = {
   [WAMessageStubType.CIPHERTEXT]: '⌛️ Waiting for this message. This may take a while',
 
   [WAMessageStubType.E2E_ENCRYPTED]: '🔒 Messages you send to this chat and calls are secured with end-to-end encryption',


### PR DESCRIPTION
Closes PLT-1022

# Context
* [Slack thread](https://a8c.slack.com/archives/C05RCR2RLHH/p1703153401723129)

When using platform-whatsapp, some times (not always) the Whatsapp server will send you an E2E_ENCRYPTED msg type (“🔒 Messages you send to this chat and calls are secured with end-to-end encryption”) for any contact that you may have opened a conversation with in the past. Just opening a new chat with that person will trigger that msg, as a new session will be created between you and that user – even if none of the users has sent any msg.

This leads to a lot of noise in the Texts sidebar, with threads for contacts that you never actually talked to.

<img src="https://github.com/TextsHQ/platform-whatsapp/assets/855995/02cdabd5-e85f-4eae-a3e1-beea2cda4aad" width="400"/>

# Description

The original problem also happens with threads where the only message is "This business works with other companies to manage this chat". 

This change makes sure than when the desktop app calls `getThreads` and we add the latest message to each thread (`addLastMessageToThreads`), we filter out any template message: this will cover the case for E2E_ENCRYPTED msg types and others.