### PR TITLE
Clean up (delete) attachments when a message is deleted for everyone

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -598,7 +598,7 @@ export default class WhatsAppAPI implements PlatformAPI {
           const msg = await this.db.getRepository(DBMessage).findOneBy({ id: mapMessageID(key) })
           if (msg && msg.attachments?.length > 0) {
             // The cache key is URL encoded (due to the HTTP request to getAsset) so we need to encode it here too
-            msg.attachments.map(a => a.fileName && this.fileCache.clear(['attachment', msg.threadID, a.id, a.fileName].map(p => encodeURIComponent(p))))
+            msg.attachments.forEach(a => a.fileName && this.fileCache.clear(['attachment', msg.threadID, a.id, a.fileName].map(p => encodeURIComponent(p))))
           }
         }
       }


### PR DESCRIPTION
Contributes to PLT-1051.

# Context
* [Linear issue](https://linear.app/texts/issue/PLT-1051/whatsapp-clean-up-attachments-on-message-deletion)
*  https://github.com/TextsHQ/platform-whatsapp/pull/46#issuecomment-1873725806

# Description

Deletes attachments from disk (file-cache) when their associated message is deleted. For now this only works for "Delete for everyone".

Doesn't work for "Delete for me" and expired messages yet. We'll have to look for a different entry point for those scenarios.