### PR TITLE
Add support for `registerForPushNotifications`

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { promises as fs } from 'fs'
-import makeWASocket, { Browsers, ChatModification, ConnectionState, delay, SocketConfig, UNAUTHORIZED_CODES, WAProto, Chat as WAChat, unixTimestampSeconds, jidNormalizedUser, isJidGroup, initAuthCreds, GroupMetadata, WAVersion, DEFAULT_CONNECTION_CONFIG, WAMessageKey, toNumber, ButtonReplyInfo, getUrlInfo, WASocket, AuthenticationCreds, MediaDownloadOptions, downloadContentFromMessage, AnyRegularMessageContent, isJidStatusBroadcast, DEFAULT_CACHE_TTLS, WAMessageStubType } from 'baileys'
-import { texts, StickerPack, PlatformAPI, OnServerEventCallback, MessageSendOptions, InboxName, LoginResult, OnConnStateChangeCallback, ReAuthError, CurrentUser, MessageContent, ConnectionError, PaginationArg, ClientContext, ActivityType, Thread, Paginated, User, PhoneNumber, ServerEvent, ConnectionStatus, ServerEventType, GetAssetOptions, AssetInfo, MessageLink, Attachment, ThreadFolderName, UserID, PaginatedWithCursors } from '@textshq/platform-sdk'
+import makeWASocket, { Browsers, ChatModification, ConnectionState, delay, SocketConfig, UNAUTHORIZED_CODES, WAProto, Chat as WAChat, unixTimestampSeconds, jidNormalizedUser, isJidGroup, initAuthCreds, GroupMetadata, WAVersion, DEFAULT_CONNECTION_CONFIG, WAMessageKey, toNumber, ButtonReplyInfo, getUrlInfo, WASocket, AuthenticationCreds, MediaDownloadOptions, downloadContentFromMessage, AnyRegularMessageContent, isJidStatusBroadcast, DEFAULT_CACHE_TTLS, WAMessageStubType, S_WHATSAPP_NET } from 'baileys'
+import { texts, StickerPack, PlatformAPI, OnServerEventCallback, MessageSendOptions, InboxName, LoginResult, OnConnStateChangeCallback, ReAuthError, CurrentUser, MessageContent, ConnectionError, PaginationArg, ClientContext, ActivityType, Thread, Paginated, User, PhoneNumber, ServerEvent, ConnectionStatus, ServerEventType, GetAssetOptions, AssetInfo, MessageLink, Attachment, ThreadFolderName, UserID, PaginatedWithCursors, NotificationsInfo } from '@textshq/platform-sdk'
 import { smartJSONStringify } from '@textshq/platform-sdk/dist/json'
 import type { Logger } from 'pino'
 import type { DataSource } from 'typeorm'
@@ -1152,5 +1152,24 @@ export default class WhatsAppAPI implements PlatformAPI {
       }
       await repo.remove(expiredMessages)
     } while (expiredMessages.length > 0)
+  }
+
+  registerForPushNotifications = async (type: keyof NotificationsInfo, token: string) => {
+    await this.client?.query({
+      tag: 'iq',
+      attrs: {
+        to: S_WHATSAPP_NET,
+        xmlns: 'urn:xmpp:whatsapp:push',
+        type: 'set',
+      },
+      content: [{
+        tag: 'config',
+        attrs: {
+          id: token,
+          num_acc: '1',
+          platform: 'gcm',
+        },
+      }],
+    })
   }
 }


### PR DESCRIPTION
Contributes to PLT-1007

# Context
* [Linear issue](https://linear.app/texts/issue/PLT-1007/whatsapp-implement-registerforpushnotifications)
* [Slack discussion](https://a8c.slack.com/archives/C05RBE5GUKE/p1706298570310819)

# Description

After reverse engineering the Android app I've found the payload that gets sent to whatsapp for registering a new GCM token:

```xml
<iq to='s.whatsapp.net' xmlns='urn:xmpp:whatsapp:push' type='set' id='[INFO_QUERY_ID]'>
  <config id='daPIAZAOGl0:APA91bFmy[...REDACTED...]' num_acc='1' platform='gcm' />
</iq>
```

This PR implements that infoQuery message. 

Note that we could move this to Baileys and expose it as a one of the functions returned with the Baileys socket. We should discuss whether we want to keep this to us or move it to Baileys and upstream it. 

# Future work
- [ ] Implement `unregisterForPushNotifications`,
- [ ] RE how whatsapp fetches the notification data