### PR TITLE
Only send exception to Sentry if reconnection is not possible

### DIFF
--- a/src/utils/generics.ts
+++ b/src/utils/generics.ts
@@ -81,8 +81,10 @@ export const canReconnect = (error: Error | undefined, retriesLeft: number) => {
     isReconnecting = false
   }
 
-  if (!isReconnecting) texts?.Sentry.captureMessage(`Whatsapp cannot reconnect. Error: ${error?.message}. Status code: ${statusCode}`, { extra: { retriesLeft } })
-  if (error) texts?.Sentry.captureException(error)
+  if (!isReconnecting) {
+    texts?.Sentry.captureMessage(`Whatsapp cannot reconnect. Error: ${error?.message}. Status code: ${statusCode}`, { extra: { retriesLeft } })
+    if (error) texts?.Sentry.captureException(error)
+  }
 
   return {
     isReconnecting,


### PR DESCRIPTION
When the app wakes up from sleep, Baileys often creates a `Boom` (`Connection was lost`) exception due to the closing of the websocket connection:
https://github.com/TextsHQ/baileys/blob/master/src/Socket/socket.ts#L420

That exception was passed to platform-whatsapp through the `connection.update` event and was being sent to Sentry even if a reconnection was possible (and therefore normal).

This was creating a lot of noise in Sentry:

<img width="958" alt="image" src="https://github.com/TextsHQ/platform-whatsapp/assets/855995/3df73c13-5712-482d-bb9d-89132be53560">
