### PR TITLE
await connection before registering for push notifications

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -147,8 +147,6 @@ export default class WhatsAppAPI implements PlatformAPI {
     await this.initPromise
   }
 
-  private connectPromise: Promise<void> | undefined
-
   private async _init() {
     await fs.mkdir(this.dataDirPath, { recursive: true })
     await makeDroppedEventsRegistryFolder({ dataDirPath: this.dataDirPath })
@@ -197,7 +195,7 @@ export default class WhatsAppAPI implements PlatformAPI {
 
     await this.cleanUpExpiredMessages()
 
-    this.connectPromise = this.connect()
+    this.connect()
   }
 
   private logoutAllInterval: NodeJS.Timer
@@ -1157,7 +1155,7 @@ export default class WhatsAppAPI implements PlatformAPI {
   }
 
   registerForPushNotifications = async (type: keyof NotificationsInfo, token: string) => {
-    await this.connectPromise
+    await this.waitForConnectionOpen()
 
     await this.client?.query({
       tag: 'iq',


### PR DESCRIPTION
[Slack Discussion](https://a8c.slack.com/archives/C05R1E7CZL6/p1708046304511289?thread_ts=1708040539.969829&cid=C05R1E7CZL6)

on iOS, the call for `registerForPushNotifications` occurs earlier than platform-whatsapp expects. The client connection still wasn't established so it was throwing a `Connection Closed` or `1006` error.

iOS Log w/ fix:
```
↑ Call whatsapp.registerForPushNotifications
↓ Return whatsapp.registerForPushNotifications in 2544ms
```
