### PR TITLE
Fix error `linkedMessageThreadID is same as message threadID, should be null`

### DIFF
--- a/src/entities/DBMessage.ts
+++ b/src/entities/DBMessage.ts
@@ -312,7 +312,7 @@ export default class DBMessage implements Message {
 
     if (STORIES_JID !== linked?.threadID) {
       mapped.linkedMessageID = linked?.id
-      mapped.linkedMessageThreadID = linked?.threadID
+      if (linked?.threadID !== threadID) mapped.linkedMessageThreadID = linked?.threadID
     }
 
     if (messageContent?.ptvMessage) {


### PR DESCRIPTION
That warning was [introduced recently in platform-api-server](https://github.com/TextsHQ/platform-api-server/commit/7d371adfb87f8b058333afd05fc7364e3c4c3eea) but platform-whatsapp was still filling `linkedMessageThreadID` even if the msg was the same thread.