### PR TITLE
Support for GROUP_MEMBER_ADD_MODE msgs

### DIFF
--- a/src/entities/DBMessage-util.ts
+++ b/src/entities/DBMessage-util.ts
@@ -198,9 +198,9 @@ export const PRE_DEFINED_MESSAGES: { [k: number]: string | ((m: WAMessage) => st
   },
   [WAMessageStubType.GROUP_MEMBERSHIP_JOIN_APPROVAL_MODE]: m => {
     if (m.messageStubParameters![0] === 'on') {
-      return m.key.fromMe ? 'You turned on admin approval to join this group' : '{{sender}} turned on admin approval to join this group'
+      return `{{${m.participant}}} turned on admin approval to join this group`
     }
-    return m.key.fromMe ? 'You turned off admin approval to join this group' : '{{sender}} turned off admin approval to join this group'
+    return `{{${m.participant}}} turned off admin approval to join this group`
   },
   [WAMessageStubType.GROUP_MEMBERSHIP_JOIN_APPROVAL_REQUEST]: '{{sender}} requested to join',
   [WAMessageStubType.GROUP_PARTICIPANT_JOINED_GROUP_AND_PARENT_GROUP]: message => `{{${message.participant}}} added you to this group and the community`,


### PR DESCRIPTION
Support for `GROUP_MEMBER_ADD_MODE` msgs. These are messages triggered when a group admin changes who can add other members to the groups (only admins or everyone).

<img width="566" alt="image" src="https://github.com/TextsHQ/platform-whatsapp/assets/855995/4b8a59c2-ebbc-4dc4-8235-606db4203454">


Also fix rendering of `GROUP_MEMBERSHIP_JOIN_APPROVAL_MODE` msgs.