### PR TITLE
Attempt to fix the "The database connection is not open" error

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -460,7 +460,10 @@ export default class WhatsAppAPI implements PlatformAPI {
 
   private registerCallbacks = () => {
     const { ev } = this.client!
-    ev.process(events => {
+    ev.process(async events => {
+      // Attempt to fix the "The database connection is not open" error
+      if (!this.db.isInitialized) await this.db.initialize()
+
       this.dataStore
         .process(events)
         .then(res => {


### PR DESCRIPTION
This is a tentative tor the ["The database connection is not open" error that's coming from platform-whatsapp](http://sentry.texts.com/organizations/texts/issues/408/?project=2&query=is%3Aunresolved+release%3ATextsv0.83.0+device_id%3Ad01a02449eab662b1b7cfb8cd05d252470936526ed3fcad2721f61510eaa65ea&referrer=issue-stream&statsPeriod=7d&stream_index=1).

(Not to be confused with [the one coming from platform-meta](http://sentry.texts.com/organizations/texts/issues/454/?project=2&query=is%3Aunresolved+database+release%3ATextsv0.83.0&referrer=issue-stream&statsPeriod=7d&stream_index=0)).

Despite the lack of sourcemaps, looking at the trace we can infer that the error is coming from [processEvents](https://github.com/TextsHQ/platform-whatsapp/blob/1358b04b11f43d0a01cddf83c89dbba4277995eb/src/utils/make-texts-baileys-store.ts#L33).

This PR just adds a check to make sure the db is initialized before calling that, and if it's not it tries to initialize it before.