### PR TITLE
fix(link-preview): set proper user-agent header for link-preview requests

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -11,7 +11,7 @@ import getDataSource from './utils/get-data-source'
 import DBUser from './entities/DBUser'
 import { canReconnect, CONNECTION_STATE_MAP, generateInstanceId, isLoggedIn, LOGGED_OUT_CODES, makeMutex, mapMessageID, numberFromJid, PARTICIPANT_ACTION_MAP, PRESENCE_MAP, profilePictureUrl, waitForAllEventsToBeHandled } from './utils/generics'
 import DBMessage from './entities/DBMessage'
-import { CHAT_MUTE_DURATION_S } from './constants'
+import { CHAT_MUTE_DURATION_S, THUMBNAIL_WIDTH_PX } from './constants'
 import DBThread from './entities/DBThread'
 import { makeDBKeyStore } from './utils/db-key-store'
 import DBParticipant from './entities/DBParticipant'
@@ -354,7 +354,15 @@ export default class WhatsAppAPI implements PlatformAPI {
   }
 
   getLinkPreview = async (link: string): Promise<MessageLink | undefined> => {
-    const info = await getUrlInfo(link, undefined)
+    const info = await getUrlInfo(link, {
+      thumbnailWidth: THUMBNAIL_WIDTH_PX,
+      fetchOpts: {
+        timeout: 6000,
+        headers: {
+          'User-Agent': texts.constants.USER_AGENT,
+        },
+      },
+    })
     if (!info) return undefined
     return {
       url: info['canonical-url'],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,3 +6,8 @@ export const CHAT_MUTE_DURATION_S = 64092211200
 export const TEN_YEARS_IN_SECONDS = 315569520
 
 export const READ_STATUS = [WAMessageStatus.READ, WAMessageStatus.PLAYED]
+
+/**
+ * https://github.com/TextsHQ/baileys/blob/c3084c8ce5f56a0666a143d518381e8b1da747dd/src/Utils/link-preview.ts#L7
+ */
+export const THUMBNAIL_WIDTH_PX = 192


### PR DESCRIPTION
### Description

The main fix is in the baileys, but this change includes a fix for related issue. Which is that some requests to link preview result in `403 Forbidden` response. In this pr we fix it by adding the `user-agent` header.

### Testing Instructions

- Follow the Testing Instructions at [baileys PR](https://github.com/TextsHQ/baileys/pull/17)
- Checkout the branch for this PR
- Update the file `package.json` and point the `baileys` to your local built. It should looks something like `"baileys": "../../baileys"`
- Run `yarn` to link the local baileys.
- Run `yarn tsc` to build the code.
- Launch the Texts app with platform-whatsapp local changes.
- Confirm the link preview sent from Texts app render vertically. Not square image.