### PR TITLE
Add `enableWAL` to DataSource options to improve concurrency of database operations

### DIFF
--- a/src/utils/get-data-source.ts
+++ b/src/utils/get-data-source.ts
@@ -14,6 +14,7 @@ const getDataSource = async (name: string, sqlitePath: string, logger: Logger) =
       database: sqlitePath,
       type: 'better-sqlite3',
       synchronize: true,
+      enableWAL: true,
       logging: logSql ? true : (texts?.isLoggingEnabled ? ['error'] : false),
       entities,
       migrations: [],


### PR DESCRIPTION
This may improve performance and limit any "database connection not open" errors.