### PR TITLE
Map pollCreationMessageV2 and pollCreationMessageV3

### DIFF
--- a/src/entities/DBMessage-util.ts
+++ b/src/entities/DBMessage-util.ts
@@ -507,8 +507,8 @@ export function* messageHeading(message: WAMessage, content: WAProto.IMessage | 
     if (content.liveLocationMessage) yield '📍 Live Location'
     if (content.productMessage?.product) yield '📦 Product'
     if (content.listMessage) yield `${content.listMessage!.title}`
-    if (content.pollCreationMessage || content.pollCreationMessageV2 || content.pollCreationMessageV3) { 
-      const poll = content.pollCreationMessage || content.pollCreationMessageV2 || content.pollCreationMessageV3
+    const poll = content.pollCreationMessage || content.pollCreationMessageV2 || content.pollCreationMessageV3
+    if (poll) {
       yield `📊 Poll: ${poll!.name}\n- ${poll?.options?.map(option => option.optionName).join('\n- ')}`
     }
     if (message.message?.templateMessage?.hydratedTemplate?.hydratedTitleText) yield message.message?.templateMessage?.hydratedTemplate?.hydratedTitleText


### PR DESCRIPTION
Fixes FDBCK-9636.

`pollCreationMessageV2` and `pollCreationMessageV3` were not being mapped, leading to _This WhatsApp message didn't render.

Now this gets rendered as:

<img width="230" alt="image" src="https://github.com/TextsHQ/platform-whatsapp/assets/855995/790fe096-e7d2-42ac-ad85-72c7517728e8">


Note we don't have support for voting on polls yet.